### PR TITLE
ELM-2803: Update logic to match routes based on a subset of route properties

### DIFF
--- a/function/tests/lambda_handler_test.py
+++ b/function/tests/lambda_handler_test.py
@@ -33,6 +33,11 @@ def test_all_routes_as_expected(lambda_context):
         "destinationCidrBlock": "10.100.0.0/14",
         "state": "active",
         "type": "propagated",
+        "transitGatewayAttachments": {
+            "resourceId": "123456789",
+            "transitGatewayAttachmentId": "tgw-attach-123456789",
+            "resourceType": "direct-connect-gateway",
+        },
     }
 
     # Setup sns topic to publish notifications
@@ -57,7 +62,7 @@ def test_all_routes_as_expected(lambda_context):
                     "DestinationCidrBlock": "10.100.0.0/14",
                     "State": "active",
                     "Type": "propagated",
-                }  # TODO: Routes should contain the expected attachment in case CIDR is static but attachment changes
+                }
             ],
         },
         lambda_context,
@@ -93,6 +98,11 @@ def test_new_route_is_identified(lambda_context):
         "destinationCidrBlock": "10.100.0.0/14",
         "state": "active",
         "type": "propagated",
+        "transitGatewayAttachments": {
+            "resourceId": "123456789",
+            "transitGatewayAttachmentId": "tgw-attach-123456789",
+            "resourceType": "direct-connect-gateway",
+        },
     }
 
     # Setup sns topic to publish notifications
@@ -159,6 +169,11 @@ def test_deleted_route_is_identified(lambda_context):
         "destinationCidrBlock": "10.100.0.0/14",
         "state": "active",
         "type": "propagated",
+        "transitGatewayAttachments": {
+            "resourceId": "123456789",
+            "transitGatewayAttachmentId": "tgw-attach-123456789",
+            "resourceType": "direct-connect-gateway",
+        },
     }
 
     # Setup sns topic to publish notifications
@@ -236,6 +251,11 @@ def test_changed_route_is_identified(lambda_context):
         "destinationCidrBlock": "10.104.0.0/14",
         "state": "active",
         "type": "propagated",
+        "transitGatewayAttachments": {
+            "resourceId": "123456789",
+            "transitGatewayAttachmentId": "tgw-attach-123456789",
+            "resourceType": "direct-connect-gateway",
+        },
     }
 
     # Setup sns topic to publish notifications

--- a/function/tests/lambda_handler_test.py
+++ b/function/tests/lambda_handler_test.py
@@ -33,7 +33,7 @@ def test_all_routes_as_expected(lambda_context):
         "destinationCidrBlock": "10.100.0.0/14",
         "state": "active",
         "type": "propagated",
-        "transitGatewayAttachments": {
+        "transitGatewayAttachments": {  # type: ignore
             "resourceId": "123456789",
             "transitGatewayAttachmentId": "tgw-attach-123456789",
             "resourceType": "direct-connect-gateway",
@@ -98,7 +98,7 @@ def test_new_route_is_identified(lambda_context):
         "destinationCidrBlock": "10.100.0.0/14",
         "state": "active",
         "type": "propagated",
-        "transitGatewayAttachments": {
+        "transitGatewayAttachments": {  # type: ignore
             "resourceId": "123456789",
             "transitGatewayAttachmentId": "tgw-attach-123456789",
             "resourceType": "direct-connect-gateway",
@@ -169,7 +169,7 @@ def test_deleted_route_is_identified(lambda_context):
         "destinationCidrBlock": "10.100.0.0/14",
         "state": "active",
         "type": "propagated",
-        "transitGatewayAttachments": {
+        "transitGatewayAttachments": {  # type: ignore
             "resourceId": "123456789",
             "transitGatewayAttachmentId": "tgw-attach-123456789",
             "resourceType": "direct-connect-gateway",
@@ -251,7 +251,7 @@ def test_changed_route_is_identified(lambda_context):
         "destinationCidrBlock": "10.104.0.0/14",
         "state": "active",
         "type": "propagated",
-        "transitGatewayAttachments": {
+        "transitGatewayAttachments": {  # type: ignore
             "resourceId": "123456789",
             "transitGatewayAttachmentId": "tgw-attach-123456789",
             "resourceType": "direct-connect-gateway",


### PR DESCRIPTION
The actual response from AWS was slightly different than the mocked AWS SDK was providing. This updates the tests to return a response similar to the real response. This requires matching routes on a subset of the properties returned from AWS to the properties configured in the service.